### PR TITLE
Update to artemis_defs, added rpi channel

### DIFF
--- a/lib/channels/artemis_channels.h
+++ b/lib/channels/artemis_channels.h
@@ -5,6 +5,7 @@
 #include <TeensyThreads.h>
 #include <rfm23.h>
 #include <Wire.h>
+#include <i2c_driver_wire.h>
 #include <Adafruit_LIS3MDL.h>
 #include <Adafruit_Sensor.h>
 #include <Adafruit_LSM6DSOX.h>
@@ -20,6 +21,7 @@ namespace Artemis
         {
             void rfm23_channel();
             void pdu_channel();
+            void rpi_channel();
         }
     }
 }

--- a/lib/channels/pdu_channel.cpp
+++ b/lib/channels/pdu_channel.cpp
@@ -1,7 +1,10 @@
 #include <artemis_channels.h>
 
-Artemis::Teensy::PDU pdu(115200);
-PacketComm packet;
+namespace
+{
+    Artemis::Teensy::PDU pdu(115200);
+    PacketComm packet;
+}
 
 void Artemis::Teensy::Channels::pdu_channel()
 {

--- a/lib/channels/rfm23_channel.cpp
+++ b/lib/channels/rfm23_channel.cpp
@@ -1,7 +1,10 @@
 #include <artemis_channels.h>
 
-Artemis::Teensy::Radio::RFM23 rfm23(RFM23_CS_PIN, RFM23_INT_PIN, hardware_spi1);
-PacketComm packet;
+namespace
+{
+    Artemis::Teensy::Radio::RFM23 rfm23(RFM23_CS_PIN, RFM23_INT_PIN, hardware_spi1);
+    PacketComm packet;
+}
 
 void Artemis::Teensy::Channels::rfm23_channel()
 {

--- a/lib/channels/rpi_channel.cpp
+++ b/lib/channels/rpi_channel.cpp
@@ -3,9 +3,12 @@
 void receiveData(int byte_count);
 void sendData();
 
-PacketComm packet;
-size_t send_index = 0;
-bool ready = false;
+namespace
+{
+    PacketComm packet;
+    size_t send_index = 0;
+    bool ready = false;
+}
 
 void Artemis::Teensy::Channels::rpi_channel()
 {

--- a/lib/channels/rpi_channel.cpp
+++ b/lib/channels/rpi_channel.cpp
@@ -1,0 +1,61 @@
+#include "artemis_channels.h"
+
+void receiveData(int byte_count);
+void sendData();
+
+PacketComm packet;
+size_t send_index = 0;
+bool ready = false;
+
+void Artemis::Teensy::Channels::rpi_channel()
+{
+    I2C_Wire1.begin(0x08);
+    I2C_Wire1.onReceive(receiveData);
+    I2C_Wire1.onRequest(sendData);
+
+    packet.wrapped.resize(0);
+
+    while (true)
+    {
+        if (!ready && PullQueue(&packet, rpi_queue, rpi_queue_mtx))
+        {
+            packet.Wrap();
+            ready = true;
+        }
+        threads.delay(10);
+    }
+}
+
+void receiveData(int byte_count)
+{
+    if (byte_count == 0)
+        return;
+
+    Threads::Scope lock(i2c1_mtx);
+    for (int i = 0; i < byte_count; i++)
+    {
+        byte data = I2C_Wire1.read();
+        Serial.println((char)data);
+    }
+}
+
+void sendData()
+{
+    if (!ready)
+    {
+        I2C_Wire1.write(255); // Send empty character when no packet available
+        return;
+    }
+
+    Threads::Scope lock(i2c1_mtx);
+    I2C_Wire1.write(packet.wrapped[send_index]);
+    Serial.print(packet.wrapped[send_index], HEX);
+    send_index++;
+    if (send_index == packet.wrapped.size())
+    {
+        send_index = 0;
+        packet.wrapped.resize(0);
+        ready = false;
+        Serial.println();
+    }
+}

--- a/lib/config/artemis_defs.cpp
+++ b/lib/config/artemis_defs.cpp
@@ -8,6 +8,7 @@ Threads::Mutex astrodev_queue_mtx;
 Threads::Mutex rfm23_queue_mtx;
 Threads::Mutex rfm98_queue_mtx;
 Threads::Mutex pdu_queue_mtx;
+Threads::Mutex rpi_queue_mtx;
 
 // Command Queues
 queue<PacketComm> main_queue;
@@ -15,10 +16,11 @@ queue<PacketComm> astrodev_queue;
 queue<PacketComm> rfm23_queue;
 queue<PacketComm> rfm98_queue;
 queue<PacketComm> pdu_queue;
+queue<PacketComm> rpi_queue;
 
 // Other Mutex
-Threads::Mutex spi_mtx;
 Threads::Mutex spi1_mtx;
+Threads::Mutex i2c1_mtx;
 
 // Utility Functions
 int kill_thread(char *thread_name)

--- a/lib/config/artemis_defs.cpp
+++ b/lib/config/artemis_defs.cpp
@@ -39,14 +39,14 @@ int kill_thread(char *thread_name)
 // Thread-safe way of pushing onto the packet queue
 int32_t PushQueue(PacketComm *packet, queue<PacketComm> &queue, Threads::Mutex &mtx)
 {
-    Threads::Scope scope(mtx);
+    Threads::Scope lock(mtx);
     queue.push(*packet);
     return 1;
 }
 // Thread-safe way of pulling from the packet queue
 int32_t PullQueue(PacketComm *packet, queue<PacketComm> &queue, Threads::Mutex &mtx)
 {
-    Threads::Scope scope(mtx);
+    Threads::Scope lock(mtx);
     if (queue.size() > 0)
     {
         *packet = queue.front();

--- a/lib/config/artemis_defs.h
+++ b/lib/config/artemis_defs.h
@@ -10,6 +10,14 @@
 #define ARTEMIS_TEMP_SENSOR_COUNT 7
 #define AREF_VOLTAGE 3.3
 
+// Nodes
+enum NODES : uint8_t
+{
+  GROUND_NODE_ID = 1,
+  TEENSY_NODE_ID = 2,
+  RPI_NODE_ID = 3,
+};
+
 // Structs
 struct thread_struct
 {
@@ -68,36 +76,26 @@ enum ARTEMIS_RADIOS : uint8_t
 {
   NONE,
   RFM23,
-  RFM98,
-  ASTRODEV,
 };
 
 // Max threads = 16
 extern vector<struct thread_struct> thread_list;
 
-// Nodes
-const uint8_t ground_node_id = 1;
-const uint8_t teensy_node_id = 2;
-const uint8_t rpi_node_id = 3;
-const uint8_t pleiades_node_id = 4;
-
 // Mutex for Command Queues
 extern Threads::Mutex main_queue_mtx;
-extern Threads::Mutex astrodev_queue_mtx;
 extern Threads::Mutex rfm23_queue_mtx;
-extern Threads::Mutex rfm98_queue_mtx;
 extern Threads::Mutex pdu_queue_mtx;
+extern Threads::Mutex rpi_queue_mtx;
 
 // Command Queues
 extern queue<PacketComm> main_queue;
-extern queue<PacketComm> astrodev_queue;
 extern queue<PacketComm> rfm23_queue;
-extern queue<PacketComm> rfm98_queue;
 extern queue<PacketComm> pdu_queue;
+extern queue<PacketComm> rpi_queue;
 
 // Other Mutex
-extern Threads::Mutex spi_mtx;
 extern Threads::Mutex spi1_mtx;
+extern Threads::Mutex i2c1_mtx;
 
 // Utility Functions
 int kill_thread(char *thread_name);

--- a/lib/rfm23/rfm23.cpp
+++ b/lib/rfm23/rfm23.cpp
@@ -10,7 +10,7 @@ namespace Artemis
 
             bool RFM23::init()
             {
-                Threads::Scope scope(spi1_mtx);
+                Threads::Scope lock(spi1_mtx);
                 SPI1.setMISO(RFM23_SPI_MISO);
                 SPI1.setMOSI(RFM23_SPI_MOSI);
                 SPI1.setSCK(RFM23_SPI_SCK);
@@ -49,7 +49,7 @@ namespace Artemis
 
             void RFM23::reset()
             {
-                Threads::Scope scope(spi1_mtx);
+                Threads::Scope lock(spi1_mtx);
                 rfm23.reset();
             }
 
@@ -58,7 +58,7 @@ namespace Artemis
                 digitalWrite(RFM23_RX_ON, HIGH);
                 digitalWrite(RFM23_TX_ON, LOW);
 
-                Threads::Scope scope(spi1_mtx);
+                Threads::Scope lock(spi1_mtx);
                 rfm23.setModeTx();
                 rfm23.send(msg, length);
                 // rfm23.waitPacketSent();
@@ -82,7 +82,7 @@ namespace Artemis
                 digitalWrite(RFM23_TX_ON, HIGH);
                 uint8_t bytes_recieved = 0;
 
-                Threads::Scope scope(spi1_mtx);
+                Threads::Scope lock(spi1_mtx);
                 rfm23.setModeRx();
                 if (rfm23.waitAvailableTimeout(100))
                 {

--- a/lib/rfm23/rfm23.h
+++ b/lib/rfm23/rfm23.h
@@ -1,7 +1,7 @@
 #ifndef _RFM23_H
 #define _RFM23_H
 
-#include <SPI.h>
+// #include <SPI.h>
 #include <RH_RF22.h>
 #include <RHHardwareSPI1.h>
 #include <artemis_defs.h>

--- a/platformio.ini
+++ b/platformio.ini
@@ -14,8 +14,5 @@ board = teensy41
 framework = arduino
 lib_deps = hsfl/artemis-teensy, Wire
 build_flags = -D COSMOS_MICRO_COSMOS
-lib_ldf_mode = chain+
-
-
-
+lib_ldf_mode = chain
  


### PR DESCRIPTION
Got rid of unused radios/nodes in artemis_defs (astrodev, rfm98, pleiades.. these were for Ke Ao oops)

Changed nodes to enum instead of uint8_t variables. Updated main to use those enums

Added rpi channel. Teensy I2C slave, RPi I2C master.
TODO:
- Dont create rpi thread upon setup.
- rpi channel is added to the thread when a command is sent to turn on the pi.
- rpi channel thread is killed using threads.kill(pid) when rpi is turned off.